### PR TITLE
Add Node export and simple hash tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,11 @@ The game will include the following activities:
 1. Breaking the Substitution Cipher
 2. Reverse engineering a hash and finding a collision
 3. Launching a DDoS attack / Rate limiting a DDoS attack
+
+## Running Tests
+
+To verify the hash function works correctly run:
+
+```bash
+node test/simpleHash.test.js
+```

--- a/script.js
+++ b/script.js
@@ -588,4 +588,7 @@ function clearPythonOutput() {
 
 // Initialize Pyodide when the sandbox is first interacted with
 document.getElementById('pythonCode').addEventListener('focus', initPyodide);
-document.querySelector('.sandbox-controls button').addEventListener('click', initPyodide); 
+document.querySelector('.sandbox-controls button').addEventListener('click', initPyodide);
+
+// Export simpleHash for Node.js environments
+if (typeof module !== 'undefined') module.exports = { simpleHash };

--- a/test/simpleHash.test.js
+++ b/test/simpleHash.test.js
@@ -1,0 +1,23 @@
+const assert = require('assert');
+
+// Minimal DOM stubs so script.js can be loaded under Node
+const dummy = new Proxy(function () {}, {
+  get: (target, prop) => {
+    if (prop === 'width' || prop === 'height') return 0;
+    return dummy;
+  },
+  apply: () => dummy,
+  set: () => true,
+});
+global.window = dummy;
+global.document = dummy;
+
+const { simpleHash } = require('../script.js');
+
+// Test that simpleHash produces expected hash for known input
+assert.strictEqual(simpleHash('AaBb'), 'A2B2');
+
+// Two different inputs with identical character counts yield the same hash
+assert.strictEqual(simpleHash('abc'), simpleHash('cba'));
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- export `simpleHash` when running under Node
- add a minimal Node test for the hash function
- document how to run the test in the README

## Testing
- `node test/simpleHash.test.js`

------
https://chatgpt.com/codex/tasks/task_e_684075aa1b7c8328aa34058f02222238